### PR TITLE
Add missing double quotes on additionalSandboxPaths

### DIFF
--- a/mkFHSEnvArgs.nix
+++ b/mkFHSEnvArgs.nix
@@ -84,7 +84,7 @@ let
       assert lib.assertMsg (e.name != "local") reservedMsg;
       assert lib.assertMsg (e.name != "cache") reservedMsg;
       assert lib.assertMsg (e.name != ".flatpak-info") reservedMsg;
-      ''test -d "$HOME/.bwrapper/${pkg.pname}/${e.name} || mkdir -p "$HOME/.bwrapper/${pkg.pname}/${e.name}"'')
+      ''test -d "$HOME/.bwrapper/${pkg.pname}/${e.name}" || mkdir -p "$HOME/.bwrapper/${pkg.pname}/${e.name}"'')
     additionalSandboxPaths);
 
   mountSandboxPaths = map (e: ''--bind "$HOME/.bwrapper/${pkg.pname}/${e.name}" "${e.path}"'') additionalSandboxPaths;


### PR DESCRIPTION
Building packages with `additionalSandboxPath` currently do not work, as it will generate a malformed script with an unmatched `"`. The code defining the path to be tested before creating the directory to be persisted in the sandbox is missing the other side of the pair of double quotes.

This PR just adds the missing one.