### PR TITLE
Find Mutter (GNOME) Xwayland auth file

### DIFF
--- a/mkFHSEnvArgs.nix
+++ b/mkFHSEnvArgs.nix
@@ -161,7 +161,9 @@ assert lib.assertMsg ((! renameDesktopFile) -> (forceAppId != null)) "If you don
 
     # there shouldn't be more than 1 xauth file, but best to be safe
     declare -a x11_auth_binds
-    xauth_files=$(ls "$XDG_RUNTIME_DIR/xauth_"*)
+    shopt -s nullglob
+    xauth_files=("$XDG_RUNTIME_DIR/xauth_"* "$XDG_RUNTIME_DIR"/.*Xwaylandauth*)
+    shopt -u nullglob
 
     for file in $xauth_files; do
       x11_auth_binds+=(--ro-bind "$file" "$file")


### PR DESCRIPTION
Mutter puts the X auth socket at:

```
$XDG_RUNTIME_DIR/.mutter-Xwaylandauth.<material>
```

So pick up such paths as well.