### PR TITLE
Ensure directory exists before writing `.flatpak-info`

### DIFF
--- a/modules/flatpak.nix
+++ b/modules/flatpak.nix
@@ -29,6 +29,7 @@ in
     # setting everything to `1` seems to work fine.
     script.preCmds.stage1 = ''
       test -f "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" && rm "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info"
+      mkdir -p "$HOME/.bwrapper/${config.app.bwrapPath}"
       printf "[Application]\nname=${config.app.id}\n\n[Instance]\ninstance-id = 0\nsystem-bus-proxy = true\nsession-bus-proxy = true\n" > "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info"
 
       mkdir -p "$XDG_RUNTIME_DIR/.flatpak/0"


### PR DESCRIPTION
On my first run of a wrapper, it failed because the directory didn't exist:

```
/run/current-system/sw/bin/gnome-text-editor: line 11: /home/danth/.bwrapper/gnome-text-editor/.flatpak-info: No such file or directory
bwrap: Can't find source path /home/danth/.bwrapper/gnome-text-editor/.flatpak-info: No such file or directory
bwrap: Can't find source path /home/danth/.bwrapper/gnome-text-editor/.flatpak-info: No such file or directory
bwrap: Can't find source path /home/danth/.bwrapper/gnome-text-editor/.flatpak-info: No such file or directory
Terminated
```

It worked on the second run because the directory is created later in the script.

(On a side note, adding `set -e` to the top of the generated script would prevent it trying to continue after errors like this.)