### PR TITLE
feat(fhsenv): only mount /nix/store instead of /nix

### DIFF
--- a/build-fhsenv-bubblewrap/default.nix
+++ b/build-fhsenv-bubblewrap/default.nix
@@ -272,7 +272,7 @@ let
         ${optionalString unshareUts "--unshare-uts"}
         ${optionalString unshareCgroup "--unshare-cgroup"}
         ${optionalString dieWithParent "--die-with-parent"}
-        --ro-bind /nix /nix
+        --ro-bind /nix/store /nix/store
         ${optionalString privateTmp "--tmpfs /tmp"}
         # Our glibc will look for the cache in its own path in `/nix/store`.
         # As such, we need a cache to exist there, because pressure-vessel

--- a/modules/dbus.nix
+++ b/modules/dbus.nix
@@ -159,7 +159,7 @@ in
       set_up_dbus_proxy() {
         ${pkgs.bubblewrap}/bin/bwrap \
           --new-session \
-          --ro-bind /nix /nix \
+          --ro-bind /nix/store /nix/store \
           --bind "/run" "/run" \
           ${lib.optionalString config.flatpak.enable ''--ro-bind "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" "/.flatpak-info" \''}
           --die-with-parent \
@@ -171,7 +171,7 @@ in
       set_up_system_dbus_proxy() {
         ${pkgs.bubblewrap}/bin/bwrap \
           --new-session \
-          --ro-bind /nix /nix \
+          --ro-bind /nix/store /nix/store \
           --bind "/run" "/run" \
           ${lib.optionalString config.flatpak.enable ''--ro-bind "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" "/.flatpak-info" \''}
           --die-with-parent \


### PR DESCRIPTION
Mounting /nix is unnecessary in most cases -- furthermore, a common impermanence configuration uses `/nix/persist` as the persistent store directory which can expose files to the sandbox that a user may not want exposed.