### PR TITLE
fix(dbus): bwrap commands when flatpak emulation is not enabled but dbus is enabled

### DIFF
--- a/modules/dbus.nix
+++ b/modules/dbus.nix
@@ -161,7 +161,7 @@ in
           --new-session \
           --ro-bind /nix /nix \
           --bind "/run" "/run" \
-          ${lib.optionalString config.flatpak.enable ''--ro-bind "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" "/.flatpak-info" \''}
+          ${lib.optionalString config.flatpak.enable ''--ro-bind "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" "/.flatpak-info"''} \
           --die-with-parent \
           --clearenv \
           -- \
@@ -173,7 +173,7 @@ in
           --new-session \
           --ro-bind /nix /nix \
           --bind "/run" "/run" \
-          ${lib.optionalString config.flatpak.enable ''--ro-bind "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" "/.flatpak-info" \''}
+          ${lib.optionalString config.flatpak.enable ''--ro-bind "$HOME/.bwrapper/${config.app.bwrapPath}/.flatpak-info" "/.flatpak-info"''} \
           --die-with-parent \
           --clearenv \
           -- \


### PR DESCRIPTION
`lib.optionalString` still includes the additional newline which messes up the `bwrap` command when `config.flatpak.enable` is false but DBus support is enabled.