### PR TITLE
feat!: remove x11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.nixos-test-history
 /result
 /result-*
 /.direnv

--- a/build-fhsenv-bubblewrap/default.nix
+++ b/build-fhsenv-bubblewrap/default.nix
@@ -226,40 +226,6 @@ let
         fi
       done
 
-      declare -a x11_args
-      # Always mount a tmpfs on /tmp/.X11-unix
-      # Rationale: https://github.com/flatpak/flatpak/blob/be2de97e862e5ca223da40a895e54e7bf24dbfb9/common/flatpak-run.c#L277
-      x11_args+=(--tmpfs /tmp/.X11-unix)
-
-      # Try to guess X socket path. This doesn't cover _everything_, but it covers some things.
-      if [[ "$DISPLAY" == *:* ]]; then
-        # recover display number from $DISPLAY formatted [host]:num[.screen]
-        display_nr=''${DISPLAY/#*:} # strip host
-        display_nr=''${display_nr/%.*} # strip screen
-        local_socket=/tmp/.X11-unix/X$display_nr
-        x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
-      fi
-
-      ${optionalString privateTmp ''
-        # sddm places XAUTHORITY in /tmp
-        if [[ "$XAUTHORITY" == /tmp/* ]]; then
-          x11_args+=(--ro-bind-try "$XAUTHORITY" "$XAUTHORITY")
-        fi
-
-        # dbus-run-session puts the socket in /tmp
-        IFS=";" read -ra addrs <<<"$DBUS_SESSION_BUS_ADDRESS"
-        for addr in "''${addrs[@]}"; do
-          [[ "$addr" == unix:* ]] || continue
-          IFS="," read -ra parts <<<"''${addr#unix:}"
-          for part in "''${parts[@]}"; do
-            printf -v part '%s' "''${part//\\/\\\\}"
-            printf -v part '%b' "''${part//%/\\x}"
-            [[ "$part" == path=/tmp/* ]] || continue
-            x11_args+=(--ro-bind-try "''${part#path=}" "''${part#path=}")
-          done
-        done
-      ''}
-
       cmd=(
         ${bubblewrap}/bin/bwrap
         --dev-bind /dev /dev
@@ -299,7 +265,6 @@ let
         "''${ro_mounts[@]}"
         "''${symlinks[@]}"
         "''${auto_mounts[@]}"
-        "''${x11_args[@]}"
         ${concatStringsSep "\n  " extraBwrapArgs}
         ${init runScript} ${initArgs}
       )

--- a/flake.lock
+++ b/flake.lock
@@ -30,27 +30,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1737371634,
-        "narHash": "sha256-fTVAWzT1UMm1lT+YxHuVPtH+DATrhYfea3B0MxG/cGw=",
+        "lastModified": 1754860581,
+        "narHash": "sha256-EM0IE63OHxXCOpDHXaTyHIOk2cNvMCGPqLt/IdtVxgk=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "a1176e2a10ce745ff8f63e4af124ece8fe0b1648",
+        "rev": "babfe85a876162c4acc9ab6fb4483df88fa1f281",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.7",
+        "ref": "v0.1.1",
         "repo": "ixx",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746904237,
-        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1758035966,
+        "narHash": "sha256-qqIJ3yxPiB0ZQTT9//nFGQYn8X/PBoJbofA7hRKZnmE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "8d4ddb19d03c65a36ad8d189d001dc32ffb0306b",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1745377448,
-        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -99,11 +99,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745046075,
-        "narHash": "sha256-8v4y6k16Ra/fiecb4DxhsoOGtzLKgKlS+9/XJ9z0T2I=",
+        "lastModified": 1758662783,
+        "narHash": "sha256-igrxT+/MnmcftPOHEb+XDwAMq3Xg1Xy7kVYQaHhPlAg=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "066afe8643274470f4a294442aadd988356a478f",
+        "rev": "7d4c0fc4ffe3bd64e5630417162e9e04e64b27a4",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1746989248,
-        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
+        "lastModified": 1758728421,
+        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
+        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -216,10 +216,6 @@
           hello-bwrapper = import ./tests/hello.nix {
             inherit pkgs;
           };
-
-          graphical-bwrapper = import ./tests/graphical.nix {
-            inherit pkgs nixpkgs;
-          };
         }
       );
     };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -72,7 +72,8 @@ let
     pkgs.lib.evalModules {
       modules = [
         mainModule
-      ] ++ mods;
+      ]
+      ++ mods;
       specialArgs = {
         inherit nixpkgs pkgs;
         inherit (pkgs) lib;

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -18,7 +18,6 @@ pkgs.testers.runNixOSTest {
             dbus.enable = false;
             sockets = {
               wayland = false;
-              x11 = false;
               pipewire = false;
               pulseaudio = false;
             };


### PR DESCRIPTION
We'll re-add X11 in the future using a more sandbox-friendly option, like `xwayland-satellite`. For now though, it's better to remove, since it allows for too many sandbox escape attacks, defeating the purpose of bwrapper entirely.

Closes #16 