### PR TITLE
Ignore /mnt bind mount and prefer tmpfs

### DIFF
--- a/build-fhsenv-bubblewrap/default.nix
+++ b/build-fhsenv-bubblewrap/default.nix
@@ -160,7 +160,7 @@ let
       initArgs ? "",
     }:
     ''
-      ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
+      ignored=(/nix /dev /proc /etc /mnt ${optionalString privateTmp "/tmp"})
       ro_mounts=()
       symlinks=()
       etc_ignored=()


### PR DESCRIPTION
/mnt is a tmpfs in the bwrap invocation, but is bind-mounted first if it exists. This causes issues for devices that are using x-systemd.automount option that are not always mounted, because /mnt then cannot bind mount the non-existant device.