### PR TITLE
Add option for custom bwrap args

### DIFF
--- a/modules/app.nix
+++ b/modules/app.nix
@@ -108,6 +108,11 @@ in
       defaultText = lib.literalExpression "config.app.package.pname";
       description = "The path under $HOME/.bwrapper where to store sandboxed application data";
     };
+    additionalUserArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "Additional arguments to pass to bwrap directly.";
+      default = [ ];
+    };
   };
 
   config = {

--- a/modules/fhsenv.nix
+++ b/modules/fhsenv.nix
@@ -7,6 +7,7 @@
 }:
 let
   cfg = config.fhsenv;
+  appcfg = config.app;
 in
 {
   options.fhsenv = {
@@ -22,11 +23,6 @@ in
       additionalArgs = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         internal = true;
-      };
-      additionalUserArgs = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        description = "Additional arguments to pass to bwrap directly.";
-        default = [];
       };
     };
     extraInstallCmds = lib.mkOption {
@@ -152,7 +148,7 @@ in
         ) config.app.env
       ));
 
-      fhsenv.bwrap.finalArgs = cfg.bwrap.baseArgs ++ cfg.bwrap.additionalArgs ++ cfg.bwrap.additionalUserArgs;
+      fhsenv.bwrap.finalArgs = cfg.bwrap.baseArgs ++ cfg.bwrap.additionalArgs ++ appcfg.additionalUserArgs;
     }
   ];
 }


### PR DESCRIPTION
Unless I missed something in the docs, there currently isn't a way to pass custom arguments to bwrap itself, only to the sandboxed application inside it. This PR adds an option to allow users to pass custom arguments to bwrap.