### PR TITLE
feat: make wrapped package overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,9 +207,9 @@
 
           # note that `pkgs` already includes the overlay we need
 
-          hello-bwrapper = import ./tests/hello.nix {
-            inherit pkgs;
-          };
+          hello-bwrapper = pkgs.callPackage ./tests/hello.nix { };
+
+          hello-bwrapper-override = pkgs.callPackage ./tests/hello-override.nix { };
         }
       );
     };

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -111,18 +111,33 @@ in
         )
       );
 
-    build.package = assertWarn (
-      if config.app.isFhsenv then
-        (config.app.package.override {
-          buildFHSEnv = config.build.fhsenv;
-        })
-      else
-        (config.fhsenv.package (
-          (fhsEnvArgs { })
+    build.package =
+      let
+        mkPackage =
+          appPkg:
+          let
+            wrapped = assertWarn (
+              if config.app.isFhsenv then
+                (appPkg.override {
+                  buildFHSEnv = config.build.fhsenv;
+                })
+              else
+                (config.fhsenv.package (
+                  (fhsEnvArgs {
+                    pkg = appPkg;
+                  })
+                  // {
+                    inherit (appPkg) pname version meta;
+                  }
+                ))
+            );
+          in
+          wrapped
           // {
-            inherit (config.app.package) pname version meta;
-          }
-        ))
-    );
+            override = args: mkPackage (appPkg.override args);
+            overrideAttrs = f: mkPackage (appPkg.overrideAttrs f);
+          };
+      in
+      mkPackage config.app.package;
   };
 }

--- a/tests/hello-override.nix
+++ b/tests/hello-override.nix
@@ -1,0 +1,44 @@
+{ testers }:
+testers.runNixOSTest {
+  name = "nix-bwrapper-hello-override";
+  nodes = {
+    machine =
+      { config, pkgs, ... }:
+      let
+        bwrapped-hello = (
+          pkgs.mkBwrapper {
+            app = {
+              package = pkgs.hello;
+              runScript = "hello";
+            };
+          }
+        );
+
+        overridden = bwrapped-hello.overrideAttrs (old: {
+          postPatch =
+            (old.postPatch or "")
+            +
+            # bash
+            ''
+              substituteInPlace src/hello.c \
+                --replace-fail "Hello, world!" "Hello, overridden!"
+            '';
+
+          doCheck = false;
+        });
+      in
+      {
+        environment.systemPackages = [
+          overridden
+        ];
+      };
+  };
+
+  testScript =
+    # python
+    ''
+      machine.wait_for_unit("default.target")
+
+      t.assertIn("Hello, overridden!", machine.succeed("hello"), "wrong stdout")
+    '';
+}

--- a/tests/hello.nix
+++ b/tests/hello.nix
@@ -1,5 +1,5 @@
-{ pkgs, ... }:
-pkgs.testers.runNixOSTest {
+{ testers }:
+testers.runNixOSTest {
   name = "nix-bwrapper-hello";
   nodes = {
     machine =
@@ -16,9 +16,11 @@ pkgs.testers.runNixOSTest {
       };
   };
 
-  testScript = ''
-    machine.wait_for_unit("default.target")
+  testScript =
+    # python
+    ''
+      machine.wait_for_unit("default.target")
 
-    machine.succeed("hello")
-  '';
+      machine.succeed("hello")
+    '';
 }


### PR DESCRIPTION
This PR adds `override` and `overrideAttrs` functions to the final wrapped package. This is useful when we need to provide the wrapped package to another module's option, which then overrides the provided package inside of their module.