### PR TITLE
feat(mounts): allow specifying different mount target and destination

### DIFF
--- a/modules/mounts.nix
+++ b/modules/mounts.nix
@@ -1,6 +1,30 @@
 { config, lib, ... }:
 let
   cfg = config.mounts;
+  mountPairType = lib.types.submodule {
+    options = {
+      from = lib.mkOption {
+        type = lib.types.str;
+        description = "Path on the host system.";
+      };
+      to = lib.mkOption {
+        type = lib.types.str;
+        description = "Path to mount within the sandbox.";
+      };
+    };
+  };
+  mountsType = lib.types.listOf (
+    lib.types.coercedTo (lib.types.either lib.types.str mountPairType) (
+      m:
+      if builtins.isString m then
+        {
+          from = m;
+          to = m;
+        }
+      else
+        m
+    ) mountPairType
+  );
 in
 {
   options.mounts = {
@@ -10,7 +34,7 @@ in
       default = true;
     };
     read = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
+      type = mountsType;
       description = ''
         Paths to be mounted read-only within the sandbox. Supports environment
         variables like `$HOME`. The default includes common paths needed for
@@ -19,7 +43,7 @@ in
       default = [ ];
     };
     readWrite = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
+      type = mountsType;
       description = ''
         Paths to be mounted read-write within the sandbox. Supports environment
         variables like `$HOME`.
@@ -66,15 +90,17 @@ in
         ))
         + "\n"
         + (builtins.concatStringsSep "\n" (
-          map (e: ''(test -d "${e}" || test -f "${e}") || mkdir -p "${e}"'') (lib.unique cfg.readWrite)
+          map (e: ''(test -d "${e.from}" || test -f "${e.from}") || mkdir -p "${e.from}"'') (
+            lib.unique cfg.readWrite
+          )
         ));
 
       fhsenv.bwrap.additionalArgs =
         (map (e: ''--bind "$HOME/.bwrapper/${config.app.bwrapPath}/${e.name}" "${e.path}"'') (
           lib.unique cfg.sandbox
         ))
-        ++ (map (e: "--ro-bind-try \"${e}\" \"${e}\"") (lib.unique cfg.read))
-        ++ (map (e: "--bind \"${e}\" \"${e}\"") (lib.unique cfg.readWrite));
+        ++ (map (e: "--ro-bind-try \"${e.from}\" \"${e.to}\"") (lib.unique cfg.read))
+        ++ (map (e: "--bind \"${e.from}\" \"${e.to}\"") (lib.unique cfg.readWrite));
     }
     (lib.mkIf cfg.privateTmp {
       script.preCmds.stage1 = ''

--- a/tests/graphical.nix
+++ b/tests/graphical.nix
@@ -21,9 +21,17 @@ let
     flatpak.enable = false;
     dbus.enable = false;
 
-    mounts.readWrite = [
-      "/home/alice/Shared"
-    ];
+    mounts = {
+      readWrite = [
+        "/home/alice/Shared"
+      ];
+      read = [
+        {
+          from = "/home/alice/ROShared";
+          to = "/home/alice/nested/ROShared";
+        }
+      ];
+    };
 
     sockets = {
       wayland = true;
@@ -41,7 +49,7 @@ pkgs.testers.runNixOSTest {
 
   nodes = {
     machine =
-      { config, pkgs, ... }:
+      { pkgs, ... }:
       {
         imports = [
           "${nixpkgs}/nixos/tests/common/wayland-cage.nix"
@@ -50,7 +58,8 @@ pkgs.testers.runNixOSTest {
         systemd.services.prepareDirs = {
           wantedBy = [ "multi-user.target" ];
           script = ''
-            mkdir -p /home/alice/{Secret,Shared}
+            mkdir -p /home/alice/{Secret,Shared,ROShared}
+            echo "bar" >> /home/alice/ROShared/foo
             chown -R alice /home/alice
           '';
         };
@@ -88,6 +97,7 @@ pkgs.testers.runNixOSTest {
       machine.wait_for_text("grass touched", 10)
       machine.send_chars("echo hard >> ~/Shared/grass\n", 0.25)
       machine.succeed(ru("cat /home/alice/Shared/grass | grep hard"))
+      machine.succeed(ru("cat /home/alice/nested/ROShared/foo | grep bar"))
 
       # confirm we cannot read secret file
       machine.send_chars("cat ~/Secret/grass\n", 0.25)


### PR DESCRIPTION
Make the file mounting a little bit more flexible, useful for mounting files inside the Nix store.