### PR TITLE
feat: use SECCOMP-based filtering instead of `--new-session`

### DIFF
--- a/build-fhsenv-bubblewrap/default.nix
+++ b/build-fhsenv-bubblewrap/default.nix
@@ -8,6 +8,7 @@
   pkgsi686Linux,
   coreutils,
   bubblewrap,
+  libseccomp,
   nixpkgs,
 }:
 
@@ -78,6 +79,21 @@ let
       "privateTmp"
     ]
   );
+
+  # Seccomp BPF filter that replaces --new-session as the CVE-2017-5226
+  # mitigation. The sandbox keeps its controlling terminal (receiving
+  # SIGWINCH on resize) while TIOCSTI keystroke injection and other
+  # dangerous syscalls are blocked. Ported from Flatpak's setup_seccomp.
+  seccompFilter =
+    runCommandLocal "${name}-seccomp-bpf"
+      {
+        nativeBuildInputs = [ libseccomp ];
+      }
+      ''
+        ${stdenv.cc}/bin/cc -O2 -I${libseccomp.dev}/include -o setup-seccomp ${./setup-seccomp.c} \
+          -L${libseccomp.lib}/lib -Wl,-rpath,${libseccomp.lib}/lib -lseccomp
+        ./setup-seccomp ${optionalString fhsenv.isMultiBuild "--multiarch"} > $out
+      '';
 
   etcBindEntries =
     let
@@ -252,9 +268,10 @@ let
         "''${ro_mounts[@]}"
         "''${symlinks[@]}"
         ${concatStringsSep "\n  " extraBwrapArgs}
+        --seccomp 3
         ${init runScript} ${initArgs}
       )
-      "''${cmd[@]}"
+      "''${cmd[@]}" 3< ${seccompFilter}
     '';
 
   bin = writeShellScript "${name}-bwrap" (bwrapCmd {

--- a/build-fhsenv-bubblewrap/setup-seccomp.c
+++ b/build-fhsenv-bubblewrap/setup-seccomp.c
@@ -1,0 +1,297 @@
+/*
+ * setup-seccomp.c — Generate a seccomp BPF filter for bwrap --seccomp
+ *
+ * This replaces `bwrap --new-session` (setsid) as the CVE-2017-5226
+ * mitigation. The sandbox keeps its controlling terminal (receiving SIGWINCH
+ * on resize) while TIOCSTI keystroke injection and other dangerous syscalls
+ * are blocked.
+ *
+ * The blocklist is ported from Flatpak's setup_seccomp() in
+ * common/flatpak-run.c:
+ * https://github.com/flatpak/flatpak/blob/main/common/flatpak-run.c
+ *
+ * Usage: setup-seccomp [--multiarch] [--allow-can] [--allow-bluetooth]
+ * Outputs a compiled cBPF program to stdout (for bwrap --seccomp FD).
+ */
+// NOLINTBEGIN(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
+// Suppressed: fprintf to stderr with a format string is sound;
+// the suggested replacement (fprintf_s) is not implemented in glibc.
+
+#include <errno.h>
+#include <linux/sched.h> /* CLONE_NEWUSER */
+#include <seccomp.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>  /* TIOCSTI */
+#include <sys/socket.h> /* AF_* */
+#include <unistd.h>
+
+/* TIOCLINUX may not be defined on all architectures. */
+#ifndef TIOCLINUX
+#define TIOCLINUX 0x541c
+#endif
+
+/* PER_LINUX — the default Linux personality, allowed by the personality filter.
+ */
+#define ALLOWED_PERSONALITY 0
+
+/*
+ * Add a rule that blocks a syscall (no arg condition).
+ * EFAULT (syscall not known for a non-native arch) is a warning, not fatal.
+ * Returns 0 on success, -1 on fatal error.
+ */
+static int block_syscall(scmp_filter_ctx ctx, int nr, int errnum) {
+  int r = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(errnum), nr, 0);
+  if (r == -EFAULT) {
+    fprintf(stderr,
+            "setup-seccomp: warning: syscall %d not known for all arches, "
+            "skipping\n",
+            nr);
+    return 0;
+  }
+  if (r < 0) {
+    fprintf(stderr, "setup-seccomp: error: failed to block syscall %d: %d\n",
+            nr, r);
+    return -1;
+  }
+  return 0;
+}
+
+/*
+ * Add a rule that blocks a syscall with an argument condition.
+ * EFAULT is a warning, not fatal (same as block_syscall).
+ */
+static int block_syscall_arg(scmp_filter_ctx ctx, int nr, int errnum,
+                             struct scmp_arg_cmp arg) {
+  int r = seccomp_rule_add(ctx, SCMP_ACT_ERRNO(errnum), nr, 1, arg);
+  if (r == -EFAULT) {
+    fprintf(stderr,
+            "setup-seccomp: warning: syscall %d not known for all arches, "
+            "skipping\n",
+            nr);
+    return 0;
+  }
+  if (r < 0) {
+    fprintf(stderr,
+            "setup-seccomp: error: failed to block syscall %d with arg: %d\n",
+            nr, r);
+    return -1;
+  }
+  return 0;
+}
+
+/*
+ * Block a socket family using seccomp_rule_add_exact.
+ * seccomp_rule_add_exact is needed for socket filtering:
+ * https://github.com/seccomp/libseccomp/issues/8
+ */
+static int block_socket_family_eq(scmp_filter_ctx ctx, int family) {
+  int r =
+      seccomp_rule_add_exact(ctx, SCMP_ACT_ERRNO(EAFNOSUPPORT),
+                             SCMP_SYS(socket), 1, SCMP_A0(SCMP_CMP_EQ, family));
+  if (r == -EFAULT) {
+    fprintf(stderr, "setup-seccomp: warning: socket syscall not known for all "
+                    "arches, skipping\n");
+    return 0;
+  }
+  if (r < 0) {
+    fprintf(stderr,
+            "setup-seccomp: error: failed to block socket family %d: %d\n",
+            family, r);
+    return -1;
+  }
+  return 0;
+}
+
+static int block_socket_family_ge(scmp_filter_ctx ctx, int family) {
+  int r =
+      seccomp_rule_add_exact(ctx, SCMP_ACT_ERRNO(EAFNOSUPPORT),
+                             SCMP_SYS(socket), 1, SCMP_A0(SCMP_CMP_GE, family));
+  if (r == -EFAULT) {
+    fprintf(stderr, "setup-seccomp: warning: socket syscall not known for all "
+                    "arches, skipping\n");
+    return 0;
+  }
+  if (r < 0) {
+    fprintf(stderr,
+            "setup-seccomp: error: failed to block socket family >= %d: %d\n",
+            family, r);
+    return -1;
+  }
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  int multiarch = 0;
+  int allow_can = 0;
+  int allow_bluetooth = 0;
+
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--multiarch") == 0)
+      multiarch = 1;
+    else if (strcmp(argv[i], "--allow-can") == 0)
+      allow_can = 1;
+    else if (strcmp(argv[i], "--allow-bluetooth") == 0)
+      allow_bluetooth = 1;
+    else {
+      fprintf(stderr, "setup-seccomp: unknown option: %s\n", argv[i]);
+      return 1;
+    }
+  }
+
+  scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_ALLOW);
+  if (!ctx) {
+    fprintf(stderr, "setup-seccomp: failed to initialize seccomp filter\n");
+    return 1;
+  }
+
+  /* On multiarch x86_64, also filter the 32-bit x86 syscall table. */
+  if (multiarch) {
+#ifdef __x86_64__
+    int r = seccomp_arch_add(ctx, SCMP_ARCH_X86);
+    if (r < 0 && r != -EEXIST) {
+      fprintf(stderr, "setup-seccomp: failed to add x86 arch: %d\n", r);
+      seccomp_release(ctx);
+      return 1;
+    }
+#endif
+  }
+
+  int ret = 0;
+
+  /* ---- Syscall blocklist (ported from Flatpak's setup_seccomp) ---- */
+
+  /* Block dmesg */
+  ret |= block_syscall(ctx, SCMP_SYS(syslog), EPERM);
+  /* Useless old syscall */
+  ret |= block_syscall(ctx, SCMP_SYS(uselib), EPERM);
+  /* Don't allow disabling accounting */
+  ret |= block_syscall(ctx, SCMP_SYS(acct), EPERM);
+  /* Don't allow reading current quota use */
+  ret |= block_syscall(ctx, SCMP_SYS(quotactl), EPERM);
+
+  /* Don't allow access to the kernel keyring */
+  ret |= block_syscall(ctx, SCMP_SYS(add_key), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(keyctl), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(request_key), EPERM);
+
+  /* Scary VM/NUMA ops */
+  ret |= block_syscall(ctx, SCMP_SYS(move_pages), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(mbind), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(get_mempolicy), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(set_mempolicy), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(migrate_pages), EPERM);
+
+  /* Don't allow subnamespace setups */
+  ret |= block_syscall(ctx, SCMP_SYS(unshare), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(setns), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(mount), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(umount), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(umount2), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(pivot_root), EPERM);
+  ret |= block_syscall(ctx, SCMP_SYS(chroot), EPERM);
+
+  /* Block clone() with CLONE_NEWUSER flag */
+#if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
+  /* CONFIG_CLONE_BACKWARDS2: flags are the second arg */
+  ret |= block_syscall_arg(
+      ctx, SCMP_SYS(clone), EPERM,
+      SCMP_A1(SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER));
+#else
+  /* Normally flags are the first arg */
+  ret |= block_syscall_arg(
+      ctx, SCMP_SYS(clone), EPERM,
+      SCMP_A0(SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER));
+#endif
+
+  /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
+  ret |= block_syscall_arg(ctx, SCMP_SYS(ioctl), EPERM,
+                           SCMP_A1(SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, TIOCSTI));
+  /* Linux virtual console copy/paste (CVE-2023-28100) */
+  ret |= block_syscall_arg(ctx, SCMP_SYS(ioctl), EPERM,
+                           SCMP_A1(SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, TIOCLINUX));
+
+  /* seccomp can't inspect clone3()'s struct clone_args, so block it entirely.
+   * Return ENOSYS so userspace falls back to clone(). (CVE-2021-41133) */
+  ret |= block_syscall(ctx, SCMP_SYS(clone3), ENOSYS);
+
+  /* New mount manipulation APIs (CVE-2021-41133) */
+  ret |= block_syscall(ctx, SCMP_SYS(open_tree), ENOSYS);
+  ret |= block_syscall(ctx, SCMP_SYS(move_mount), ENOSYS);
+  ret |= block_syscall(ctx, SCMP_SYS(fsopen), ENOSYS);
+  ret |= block_syscall(ctx, SCMP_SYS(fsconfig), ENOSYS);
+  ret |= block_syscall(ctx, SCMP_SYS(fsmount), ENOSYS);
+  ret |= block_syscall(ctx, SCMP_SYS(fspick), ENOSYS);
+  ret |= block_syscall(ctx, SCMP_SYS(mount_setattr), ENOSYS);
+
+  /* ---- Non-devel blocklist ---- */
+
+  /* Profiling operations (perf has been the source of many CVEs) */
+  ret |= block_syscall(ctx, SCMP_SYS(perf_event_open), EPERM);
+  /* Don't allow switching to BSD emulation or other personalities.
+   * Allow personality(0) (PER_LINUX), block everything else. */
+  ret |= block_syscall_arg(ctx, SCMP_SYS(personality), EPERM,
+                           SCMP_A0(SCMP_CMP_NE, ALLOWED_PERSONALITY));
+  /* Don't allow ptrace */
+  ret |= block_syscall(ctx, SCMP_SYS(ptrace), EPERM);
+
+  /* ---- Non-multiarch blocklist ---- */
+
+  if (!multiarch) {
+    /* modify_ldt is a historic source of information leaks.
+     * Required for 16-bit apps and some Wine patches in multiarch. */
+    ret |= block_syscall(ctx, SCMP_SYS(modify_ldt), EPERM);
+  }
+
+  if (ret != 0) {
+    fprintf(stderr, "setup-seccomp: failed to add blocklist rules\n");
+    seccomp_release(ctx);
+    return 1;
+  }
+
+  /* ---- Socket family filtering ---- */
+  /* Blocklist all but AF_UNSPEC, AF_LOCAL, AF_INET, AF_INET6, AF_NETLINK.
+   * Optionally allow AF_CAN and AF_BLUETOOTH.
+   * The array MUST be sorted in ascending order for the gap-filling logic. */
+  int allowed_families[7] = {
+      AF_UNSPEC,  /* 0 */
+      AF_LOCAL,   /* 1 */
+      AF_INET,    /* 2 */
+      AF_INET6,   /* 10 */
+      AF_NETLINK, /* 16 */
+  };
+  int n_allowed = 5;
+
+  if (allow_can)
+    allowed_families[n_allowed++] = AF_CAN; /* 29 */
+  if (allow_bluetooth)
+    allowed_families[n_allowed++] = AF_BLUETOOTH; /* 31 */
+
+  int last_allowed = -1;
+  for (int i = 0; i < n_allowed; i++) {
+    int family = allowed_families[i];
+    for (int d = last_allowed + 1; d < family; d++)
+      ret |= block_socket_family_eq(ctx, d);
+    last_allowed = family;
+  }
+  /* Block everything above the last allowed family */
+  ret |= block_socket_family_ge(ctx, last_allowed + 1);
+
+  if (ret != 0) {
+    fprintf(stderr, "setup-seccomp: failed to add socket filtering rules\n");
+    seccomp_release(ctx);
+    return 1;
+  }
+
+  /* ---- Export BPF to stdout ---- */
+  int r = seccomp_export_bpf(ctx, STDOUT_FILENO);
+  if (r != 0) {
+    fprintf(stderr, "setup-seccomp: failed to export BPF: %d\n", r);
+    seccomp_release(ctx);
+    return 1;
+  }
+
+  seccomp_release(ctx);
+  return 0;
+}
+// NOLINTEND(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,10 @@
               mdbook-admonish
               treefmtEval.config.build.wrapper
             ];
+
+            buildInputs = [
+              pkgs.libseccomp
+            ];
           };
         }
       );
@@ -210,6 +214,8 @@
           hello-bwrapper = pkgs.callPackage ./tests/hello.nix { };
 
           hello-bwrapper-override = pkgs.callPackage ./tests/hello-override.nix { };
+
+          seccomp = pkgs.callPackage ./tests/seccomp.nix { };
         }
       );
     };

--- a/modules/fhsenv.nix
+++ b/modules/fhsenv.nix
@@ -139,7 +139,6 @@ in
       fhsenv.package = pkgs.callPackage ../build-fhsenv-bubblewrap { inherit nixpkgs; };
 
       fhsenv.bwrap.baseArgs = [
-        "--new-session"
         "--tmpfs /home"
         "--tmpfs /mnt"
         "--tmpfs /run"

--- a/tests/seccomp-probe.c
+++ b/tests/seccomp-probe.c
@@ -1,0 +1,156 @@
+/*
+ * seccomp-probe.c — Verify the seccomp filter is working correctly.
+ *
+ * Runs INSIDE the bwrap sandbox and tests:
+ *   — Session inheritance (SIGWINCH propagation proxy)
+ *   — Blocked syscalls return EPERM/ENOSYS/EAFNOSUPPORT
+ *   — Allowed syscalls (TIOCGWINSZ, socket(AF_INET)) work normally
+ *
+ * Exit 0 = all tests pass, 1 = any test fails.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static int tests = 0;
+static int passed = 0;
+static int failed = 0;
+static char line[256];
+
+#define TEST(cond, fmt, ...)                                                   \
+  do {                                                                         \
+    tests++;                                                                   \
+    snprintf(line, sizeof(line), fmt, ##__VA_ARGS__);                          \
+    if ((cond)) {                                                              \
+      passed++;                                                                \
+      printf("  PASS: %s\n", line);                                            \
+    } else {                                                                   \
+      failed++;                                                                \
+      printf("  FAIL: %s\n", line);                                            \
+    }                                                                          \
+  } while (0)
+
+#define TRY_SYSCALL(nr, ...) syscall((long)(nr), ##__VA_ARGS__)
+#define CHK_EPERM(nr, name) CHK_ERRNO(nr, EPERM, name)
+#define CHK_ENOSYS(nr, name) CHK_ERRNO(nr, ENOSYS, name)
+#define CHK_EAFNOSUPPORT(nr, name) CHK_ERRNO(nr, EAFNOSUPPORT, name)
+
+#define CHK_ERRNO(nr, expected, name)                                          \
+  do {                                                                         \
+    errno = 0;                                                                 \
+    TRY_SYSCALL(nr);                                                           \
+    TEST(errno == (expected), "%s -> errno=%d (%s)", name, errno,              \
+         strerror(errno));                                                     \
+  } while (0)
+
+/* Synchronous kill — test that SIGWINCH can be sent within the sandbox.
+ * We send to our own pid, not the group, so it's delivered directly. */
+static volatile int sigwinch_caught = 0;
+static void sigwinch_handler(int sig) {
+  (void)sig;
+  sigwinch_caught = 1;
+}
+
+int main(void) {
+  /* ── SIGWINCH propagation blinker ── */
+  /* Without --new-session the sandbox inherits the parent session, so
+     sid != pid.  With --new-session (the old broken behaviour) setsid()
+     makes the process a session leader, sid == pid. */
+  int sid = getsid(0);
+  int pgid = getpgrp();
+  int pid = getpid();
+  printf("SIGWINCH_BLINKER: sid=%d pgid=%d pid=%d\n", sid, pgid, pid);
+
+  /* Also test that we can actually send WINCH and have a handler fire.
+     This proves signal delivery within the sandbox isn't blocked. */
+  signal(SIGWINCH, sigwinch_handler);
+  sigwinch_caught = 0;
+  kill(pid, SIGWINCH);
+  TEST(sigwinch_caught, "SIGWINCH handler fired after kill(getpid(), WINCH)");
+
+  /* ── Core CVE fixes ── */
+
+  /* CVE-2017-5226 TIOCSTI keystroke injection */
+  errno = 0;
+  ioctl(STDIN_FILENO, TIOCSTI, (char[]){'X'});
+  TEST(errno == EPERM, "CVE-2017-5226: ioctl(TIOCSTI) -> errno=%d (%s)", errno,
+       strerror(errno));
+
+  /* CVE-2023-28100 TIOCLINUX virtual-console copy/paste */
+  errno = 0;
+  ioctl(STDIN_FILENO, 0x541C, NULL);
+  TEST(errno == EPERM, "CVE-2023-28100: ioctl(TIOCLINUX) -> errno=%d (%s)",
+       errno, strerror(errno));
+
+  /* TIOCGWINSZ must NOT be blocked (terminal-size query for resize). */
+  errno = 0;
+  ioctl(STDOUT_FILENO, TIOCGWINSZ, NULL);
+  TEST(errno != EPERM, "TIOCGWINSZ not blocked (errno=%d != EPERM)", errno);
+
+  /* ── Blocked syscalls ── */
+  /* (all should return EPERM unless noted) */
+  CHK_EPERM(SYS_ptrace, "ptrace");
+  CHK_EPERM(SYS_mount, "mount");
+  CHK_EPERM(SYS_unshare, "unshare");
+  CHK_EPERM(SYS_setns, "setns");
+  CHK_EPERM(SYS_pivot_root, "pivot_root");
+  CHK_EPERM(SYS_chroot, "chroot");
+  CHK_EPERM(SYS_syslog, "syslog (dmesg)");
+  CHK_EPERM(SYS_perf_event_open, "perf_event_open");
+  CHK_EPERM(SYS_keyctl, "keyctl");
+  CHK_EPERM(SYS_add_key, "add_key");
+  CHK_EPERM(SYS_request_key, "request_key");
+
+  /* personality(anything but 0) → EPERM */
+  errno = 0;
+  TRY_SYSCALL(SYS_personality, 0x1);
+  TEST(errno == EPERM, "personality(0x1) -> errno=%d (%s)", errno,
+       strerror(errno));
+
+  /* modify_ldt — only filtered on non-multiarch; test it anyway */
+  errno = 0;
+  TRY_SYSCALL(SYS_modify_ldt, 0, NULL, 0);
+  TEST(errno == EPERM, "modify_ldt -> errno=%d (%s)", errno, strerror(errno));
+
+#ifdef SYS_clone3
+  CHK_ENOSYS(SYS_clone3, "clone3 -> ENOSYS (CVE-2021-41133)");
+#endif
+
+  /* ── Socket family filtering ── */
+  /* AF_PACKET (17) should be blocked with EAFNOSUPPORT */
+  errno = 0;
+  int sock = (int)TRY_SYSCALL(SYS_socket, 17, SOCK_STREAM, 0);
+  int sock_err = errno;
+  if (sock >= 0)
+    close(sock);
+  TEST(sock_err == EAFNOSUPPORT, "socket(AF_PACKET) -> errno=%d (%s)", sock_err,
+       strerror(sock_err));
+
+  /* AF_INET (2) should be allowed — don't use SOCK_STREAM since that would
+   * try to connect to something; just create a raw/seqpacket placeholder. */
+  errno = 0;
+  int inet_sock = (int)TRY_SYSCALL(SYS_socket, AF_INET, SOCK_DGRAM, 0);
+  int inet_err = errno;
+  if (inet_sock >= 0)
+    close(inet_sock);
+  TEST(inet_sock >= 0, "socket(AF_INET) -> created fd=%d (allowed)", inet_sock);
+
+  /* ── Summary ── */
+  printf("\n=== RESULTS: %d tests, %d passed, %d failed ===\n", tests, passed,
+         failed);
+  if (failed > 0) {
+    printf("SOME TEST FAILED\n");
+    return 1;
+  }
+  printf("ALL TESTS PASSED\n");
+  return 0;
+}

--- a/tests/seccomp.nix
+++ b/tests/seccomp.nix
@@ -1,0 +1,62 @@
+{ testers, pkgs }:
+
+let
+  seccompProbe = pkgs.stdenv.mkDerivation {
+    pname = "seccomp-probe";
+    version = "1";
+    dontUnpack = true;
+    buildPhase = ''
+      cc -O2 ${./seccomp-probe.c} -o probe
+    '';
+    installPhase = ''
+      mkdir -p $out/bin
+      cp probe $out/bin/probe
+    '';
+  };
+
+  bwrappedProbe = pkgs.mkBwrapper {
+    app = {
+      package = seccompProbe;
+      runScript = "probe";
+    };
+  };
+in
+testers.runNixOSTest {
+  name = "nix-bwrapper-seccomp";
+
+  nodes = {
+    machine =
+      { config, pkgs, ... }:
+      {
+        environment.systemPackages = [ bwrappedProbe ];
+      };
+  };
+
+  testScript =
+    # python
+    ''
+      machine.wait_for_unit("default.target")
+      result = machine.succeed("seccomp-probe")
+      print("=== probe output ===")
+      print(result)
+      print("====================")
+
+      # All tests from the C probe must pass
+      t.assertIn("ALL TESTS PASSED", result,
+                 "seccomp probe should pass all tests")
+
+      # Parse the SIGWINCH_BLINKER line: sid != pid means session inherited,
+      # which means SIGWINCH from the controlling terminal WILL reach the TUI.
+      for line in result.split("\n"):
+          if "SIGWINCH_BLINKER" in line:
+              parts = line.split()
+              sid = int(parts[1].split("=")[1])
+              pid = int(parts[3].split("=")[1])
+              t.assertTrue(sid != pid,
+                  "SIGWINCH propagation: sid (%d) should differ from pid (%d) "
+                  "- sandbox inherited the parent session (no setsid)"
+                  % (sid, pid))
+              print("SIGWINCH_BLINKER: sid=%d != pid=%d -> session inherited" % (sid, pid))
+              break
+    '';
+}

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,17 +1,29 @@
-{ ... }:
+{ pkgs, lib, ... }:
 {
-  programs.nixfmt.enable = true;
-  programs.typos = {
-    enable = true;
-    includes = [
-      "*.md"
-      "*.nix"
-    ];
-  };
-  programs.mdformat = {
-    enable = true;
-    settings = {
-      wrap = 120;
+  programs = {
+    clang-format.enable = true;
+    clang-tidy.enable = true;
+    nixfmt.enable = true;
+    typos = {
+      enable = true;
+      includes = [
+        "*.md"
+        "*.nix"
+      ];
+    };
+    mdformat = {
+      enable = true;
+      settings = {
+        wrap = 120;
+      };
     };
   };
+
+  settings.formatter.clang-tidy.options =
+    let
+      cLibs = [
+        pkgs.libseccomp
+      ];
+    in
+    map (e: "--extra-arg-before=-I${lib.getDev e}/include") cLibs;
 }


### PR DESCRIPTION
`--new-session` breaks certain functionality for TUI apps, for example detecting when a terminal is resized. Its purpose is to prevent sandbox-escapes, as seen in CVE-2017-5226 and CVE-2023-28100, so we cannot just disable it or make it configurable.

Flatpak solves this by using a custom SECCOMP BPF filter that is used to block only the syscalls that are considered dangerous, and allowing the rest.