### PR TITLE
feat(seccomp): allow nested user namespaces for application sandboxes

### DIFF
--- a/build-fhsenv-bubblewrap/default.nix
+++ b/build-fhsenv-bubblewrap/default.nix
@@ -28,6 +28,7 @@
   unshareCgroup ? false,
   privateTmp ? false,
   dieWithParent ? true,
+  allowNestedUserNamespaces ? false,
   ...
 }@args:
 
@@ -77,6 +78,7 @@ let
       "unsharePid"
       "unshareIpc"
       "privateTmp"
+      "allowNestedUserNamespaces"
     ]
   );
 
@@ -92,7 +94,10 @@ let
       ''
         ${stdenv.cc}/bin/cc -O2 -I${libseccomp.dev}/include -o setup-seccomp ${./setup-seccomp.c} \
           -L${libseccomp.lib}/lib -Wl,-rpath,${libseccomp.lib}/lib -lseccomp
-        ./setup-seccomp ${optionalString fhsenv.isMultiBuild "--multiarch"} > $out
+        ./setup-seccomp \
+          ${optionalString fhsenv.isMultiBuild "--multiarch"} \
+          ${optionalString allowNestedUserNamespaces "--allow-user-namespaces"} \
+          > $out
       '';
 
   etcBindEntries =

--- a/build-fhsenv-bubblewrap/setup-seccomp.c
+++ b/build-fhsenv-bubblewrap/setup-seccomp.c
@@ -11,6 +11,7 @@
  * https://github.com/flatpak/flatpak/blob/main/common/flatpak-run.c
  *
  * Usage: setup-seccomp [--multiarch] [--allow-can] [--allow-bluetooth]
+ *                      [--allow-user-namespaces]
  * Outputs a compiled cBPF program to stdout (for bwrap --seccomp FD).
  */
 // NOLINTBEGIN(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
@@ -125,6 +126,7 @@ int main(int argc, char *argv[]) {
   int multiarch = 0;
   int allow_can = 0;
   int allow_bluetooth = 0;
+  int allow_user_namespaces = 0;
 
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "--multiarch") == 0)
@@ -133,6 +135,8 @@ int main(int argc, char *argv[]) {
       allow_can = 1;
     else if (strcmp(argv[i], "--allow-bluetooth") == 0)
       allow_bluetooth = 1;
+    else if (strcmp(argv[i], "--allow-user-namespaces") == 0)
+      allow_user_namespaces = 1;
     else {
       fprintf(stderr, "setup-seccomp: unknown option: %s\n", argv[i]);
       return 1;
@@ -182,27 +186,35 @@ int main(int argc, char *argv[]) {
   ret |= block_syscall(ctx, SCMP_SYS(set_mempolicy), EPERM);
   ret |= block_syscall(ctx, SCMP_SYS(migrate_pages), EPERM);
 
-  /* Don't allow subnamespace setups */
-  ret |= block_syscall(ctx, SCMP_SYS(unshare), EPERM);
+  /* Don't allow subnamespace setups. Applications with their own sandbox may
+   * opt in to creating a user namespace, but no other unshare() flags. */
+  if (allow_user_namespaces)
+    ret |= block_syscall_arg(ctx, SCMP_SYS(unshare), EPERM,
+                             SCMP_A0(SCMP_CMP_NE, CLONE_NEWUSER));
+  else
+    ret |= block_syscall(ctx, SCMP_SYS(unshare), EPERM);
   ret |= block_syscall(ctx, SCMP_SYS(setns), EPERM);
   ret |= block_syscall(ctx, SCMP_SYS(mount), EPERM);
   ret |= block_syscall(ctx, SCMP_SYS(umount), EPERM);
   ret |= block_syscall(ctx, SCMP_SYS(umount2), EPERM);
   ret |= block_syscall(ctx, SCMP_SYS(pivot_root), EPERM);
-  ret |= block_syscall(ctx, SCMP_SYS(chroot), EPERM);
+  if (!allow_user_namespaces)
+    ret |= block_syscall(ctx, SCMP_SYS(chroot), EPERM);
 
   /* Block clone() with CLONE_NEWUSER flag */
+  if (!allow_user_namespaces) {
 #if defined(__s390__) || defined(__s390x__) || defined(__CRIS__)
-  /* CONFIG_CLONE_BACKWARDS2: flags are the second arg */
-  ret |= block_syscall_arg(
-      ctx, SCMP_SYS(clone), EPERM,
-      SCMP_A1(SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER));
+    /* CONFIG_CLONE_BACKWARDS2: flags are the second arg */
+    ret |= block_syscall_arg(
+        ctx, SCMP_SYS(clone), EPERM,
+        SCMP_A1(SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER));
 #else
-  /* Normally flags are the first arg */
-  ret |= block_syscall_arg(
-      ctx, SCMP_SYS(clone), EPERM,
-      SCMP_A0(SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER));
+    /* Normally flags are the first arg */
+    ret |= block_syscall_arg(
+        ctx, SCMP_SYS(clone), EPERM,
+        SCMP_A0(SCMP_CMP_MASKED_EQ, CLONE_NEWUSER, CLONE_NEWUSER));
 #endif
+  }
 
   /* Don't allow faking input to the controlling tty (CVE-2017-5226) */
   ret |= block_syscall_arg(ctx, SCMP_SYS(ioctl), EPERM,

--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -97,6 +97,8 @@
               package = pkgs.brave;
               runScript = "brave";
             };
+            # Chromium's internal sandbox needs to create nested namespaces.
+            fhsenv.opts.allowNestedUserNamespaces = true;
           };
 
           lutris-wrapped = pkgs.mkBwrapper ({
@@ -180,6 +182,8 @@
                 pkgs.libdbusmenu
               ];
             };
+            # Electron's internal sandbox needs to create nested namespaces.
+            fhsenv.opts.allowNestedUserNamespaces = true;
             mounts.readWrite = [
               "$HOME/Downloads"
             ];
@@ -211,6 +215,8 @@
                 ELECTRON_TRASH = "gio";
               };
             };
+            # Electron's internal sandbox needs to create nested namespaces.
+            fhsenv.opts.allowNestedUserNamespaces = true;
             mounts.readWrite = [
               "$XDG_RUNTIME_DIR/app/com.discordapp.Discord"
               "$XDG_RUNTIME_DIR/speech-dispatcher"

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -21,6 +21,7 @@ let
         unsharePid
         unshareNet
         dieWithParent
+        allowNestedUserNamespaces
         ;
 
       inherit runScript;
@@ -81,6 +82,7 @@ in
         unshareCgroup ? false,
         privateTmp ? false,
         dieWithParent ? true,
+        allowNestedUserNamespaces ? false,
         ...
       }@args:
       let

--- a/modules/fhsenv.nix
+++ b/modules/fhsenv.nix
@@ -96,6 +96,19 @@ in
         '';
         default = true;
       };
+      allowNestedUserNamespaces = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Allow the sandboxed application to create a nested user namespace.
+          This is required by applications such as Chromium and Electron that
+          set up their own process sandbox.
+
+          Enabling this permits `clone(CLONE_NEWUSER)`,
+          `unshare(CLONE_NEWUSER)`, and `chroot`. All other seccomp rules,
+          including the terminal ioctl protections, remain active.
+        '';
+      };
     };
   };
 


### PR DESCRIPTION
The seccomp filter introduced in #53 blocks the namespace operations used by Chromium and Electron to create their internal process sandbox. As a result, the existing Brave, Slack, and Discord examples fail with either an invalid SUID sandbox helper or `No usable sandbox`.

This adds an opt-in option `fhsenv.opts.allowNestedUserNamespaces` to disable the seccomp filter. Right now this option only permits the operations needed by Chromium's user-namespace sandbox. Other `unshare` flags remain blocked.

Most importantly, the rules added for CVE-2017-5226 and CVE-2023-28100 remain active. This therefore does not make the seccomp filter optional or revert the protection introduced in #53.